### PR TITLE
Some fixes to operand code to remove uneccessary memory/register reads t...

### DIFF
--- a/shorthand.py
+++ b/shorthand.py
@@ -211,7 +211,7 @@ def undef_(register):
     again.
     """
 
-    return reil.Instruction(reil.UNDEF, register, None, None)
+    return reil.Instruction(reil.UNDEF, None, None, register)
 
 
 def unkn_():

--- a/x86/bitwise.py
+++ b/x86/bitwise.py
@@ -195,7 +195,7 @@ def x86_ror(ctx, i):
 
     # TODO: compute carry flag
 
-    if isinstance(b, pyreil.ImmediateOperand) and b.value == 1:
+    if isinstance(b, reil.ImmediateOperand) and b.value == 1:
         # TODO: compute overflow flag
         pass
     else:

--- a/x86/translator.py
+++ b/x86/translator.py
@@ -250,9 +250,9 @@ def print_instruction(i):
 
 
 def unknown_opcode(ctx, i):
-    print_instruction(i)
-    print(i.id)
-    raise NotImplementedError()
+    #print_instruction(i)
+    #print(i.id)
+    #raise NotImplementedError()
 
     ctx.emit(  unkn_())
 
@@ -346,7 +346,7 @@ class X86_64TranslationContext(TranslationContext):
             capstone.x86.X86_REG_R13:   r('r13', 64),
             capstone.x86.X86_REG_R14:   r('r14', 64),
             capstone.x86.X86_REG_R15:   r('r15', 64),
-            capstone.x86.X86_REG_RIP:   r('rip', 64),
+            #capstone.x86.X86_REG_RIP:   r('rip', 64),
 
             capstone.x86.X86_REG_FS:    r('fsbase', 64),
             capstone.x86.X86_REG_GS:    r('gsbase', 64),


### PR DESCRIPTION
...o

determine operand sizes.

Change to the handling of RIP-relative addressing to instead use a constant
value for the address of the next instruction. Not sure this is a preferable
approach, but it makes it easier for some analysis tools.

Change to the arguments of the undef instruction to match the behaviour of
BinNavi
